### PR TITLE
Do not attempt system install for Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,19 +4,12 @@ on:
   - push
   - pull_request
 
-env:
-  PERL5LIB: c:\cx\lib\perl5
-  PERL_LOCAL_LIB_ROOT: c:/cx
-  PERL_MB_OPT: --install_base C:/cx
-  PERL_MM_OPT: INSTALL_BASE=C:/cx
-  ALIEN_INSTALL_TYPE: system
-
 jobs:
   perl:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - run: cpan Alien::Build PkgConfig Sort::Versions
+      - run: cpan Alien::Build PkgConfig Sort::Versions Alien::MSYS
       - run: perl Makefile.PL
       - run: make
       - run: make test TEST_VERBOSE=1


### PR DESCRIPTION
The `ALIEN_INSTALL_TYPE` environment variable is used to override the probe logic to force either a share or system install.  CI on Windows wasn't working because it was trying to force a system install without preping the system by pre-installing libtiff.